### PR TITLE
Fix bug where config will not persist correctly

### DIFF
--- a/_.mod.lua
+++ b/_.mod.lua
@@ -414,8 +414,8 @@ local settings = {};
 function settings.new(fontModule, attached, child)
 	local self = setmetatable({}, {__index = settings});
 	
-	settings.child = child;
-	settings.attached = attached;
+	self.child = child;
+	self.attached = attached;
 	
 	-- place data in new format for easy access
 	self.information = fontModule.font.information;


### PR DESCRIPTION
I'm aware this may never be merged in, I'm unsure of how often the maintainer checks this repo, however I am sharing it to aid anyone else who may be facing the same issue.

Fixes a bug where the wrong settings.child and settings.attached values are set - breaking the config as any updates to the text will follow the X/Y alignment, TextColor, etc of the last GuiObject to be wrapped.